### PR TITLE
Location state and helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,16 @@ public void error() {
 ### Mode Tracking
 
 Flint tracks the user's current mode and optionally the plot and node they are on, you can access this info using
-**Flint.getUser().getMode()**, **Flint.getUser().getPlot()**, and **Flint.getUser().getNode()**.
+**Flint.getUser().getMode()**, **Flint.getUser().getPlot()**, and **Flint.getUser().getNode()**.  
+Use **Flint.getUser().isLocationConfirmed()** to check whether the current location state has been
+confirmed by `/locate`, or is only Flint's best currently inferred state.
 
 ```java
 public boolean shouldShowPlotOverlay() {
-    return Flint.getUser().getMode() == Mode.PLAY && Flint.getUser().getPlot().handle() == "myplot";
+    Plot plot = Flint.getUser().getPlot();
+    return Flint.getUser().isInPlay()
+            && plot != null
+            && plot.getHandle().equals("myplot");
 }
 ```
 
@@ -118,7 +123,10 @@ TODO
 
 An enum containing every mode the user can be in,
 you can check whether a mode means the user is in a plot
-or if they are in a mode that allows them to modify a plot with `Mode.isInPlot()` and `Mode.isEditor()` respectively.
+or if they are in a mode that allows them to modify a plot with `Mode.isInPlot()` and `Mode.isEditor()` respectively.  
+Specific mode checks are available with helpers such as `Mode.isInPlay()`, `Mode.isInDev()`, and `Mode.isAtSpawn()`.  
+The same helpers are available on `User`, plus confirmed variants such as `User.isConfirmedInPlay()` and
+`User.isConfirmedInPlot()` that return false unless the current location state came from `/locate`.
 
 #### Plot
 

--- a/src/main/java/dev/dfonline/flint/User.java
+++ b/src/main/java/dev/dfonline/flint/User.java
@@ -21,6 +21,7 @@ public final class User {
     private @Nullable Plot plot;
     private @Nullable Node node;
     private int nodeId;
+    private boolean locationConfirmed = false;
 
     public ClientPlayerEntity getPlayer() {
         ClientPlayerEntity player = Flint.getClient().player;
@@ -33,6 +34,69 @@ public final class User {
 
     public @NotNull Mode getMode() {
         return this.mode;
+    }
+
+    /**
+     * @return Whether the current location state has been confirmed by /locate.
+     */
+    public boolean isLocationConfirmed() {
+        return this.locationConfirmed;
+    }
+
+    public boolean isAtSpawn() {
+        return this.mode.isAtSpawn();
+    }
+
+    public boolean isConfirmedAtSpawn() {
+        return this.locationConfirmed && this.isAtSpawn();
+    }
+
+    public boolean isInPlay() {
+        return this.mode.isInPlay();
+    }
+
+    public boolean isConfirmedInPlay() {
+        return this.locationConfirmed && this.isInPlay();
+    }
+
+    public boolean isInDev() {
+        return this.mode.isInDev();
+    }
+
+    public boolean isConfirmedInDev() {
+        return this.locationConfirmed && this.isInDev();
+    }
+
+    public boolean isInBuild() {
+        return this.mode.isInBuild();
+    }
+
+    public boolean isConfirmedInBuild() {
+        return this.locationConfirmed && this.isInBuild();
+    }
+
+    public boolean isCodeSpectating() {
+        return this.mode.isCodeSpectating();
+    }
+
+    public boolean isConfirmedCodeSpectating() {
+        return this.locationConfirmed && this.isCodeSpectating();
+    }
+
+    public boolean isInPlot() {
+        return this.mode.isInPlot();
+    }
+
+    public boolean isConfirmedInPlot() {
+        return this.locationConfirmed && this.isInPlot();
+    }
+
+    public boolean isEditor() {
+        return this.mode.isEditor();
+    }
+
+    public boolean isConfirmedEditor() {
+        return this.locationConfirmed && this.isEditor();
     }
 
     @ApiStatus.Internal
@@ -70,6 +134,11 @@ public final class User {
 
     public void setNodeId(int nodeId) {
         this.nodeId = nodeId;
+    }
+
+    @ApiStatus.Internal
+    public void setLocationConfirmed(boolean locationConfirmed) {
+        this.locationConfirmed = locationConfirmed;
     }
 
     public void sendMessage(Message message) {

--- a/src/main/java/dev/dfonline/flint/feature/impl/ModeTrackerFeature.java
+++ b/src/main/java/dev/dfonline/flint/feature/impl/ModeTrackerFeature.java
@@ -54,6 +54,8 @@ public class ModeTrackerFeature implements PacketListeningFeature, TickedFeature
             LOGGER.info("Setting to mode " + mode);
         }
 
+        Flint.getUser().setLocationConfirmed(false);
+
         if (FlintAPI.shouldConfirmLocationWithLocate() && mode != Mode.NONE) {
             hasQueuedLocate = true;
         } else {
@@ -109,6 +111,7 @@ public class ModeTrackerFeature implements PacketListeningFeature, TickedFeature
                 LocateFeature.requestLocate(name).thenAccept(locate -> {
                     Flint.getUser().setNode(locate.node());
                     Flint.getUser().setNodeId(locate.nodeId());
+                    Flint.getUser().setLocationConfirmed(true);
 
                     Vec3i newOrigin;
                     if (locate.mode() == Mode.DEV) {

--- a/src/main/java/dev/dfonline/flint/feature/impl/StateDebugDisplayFeature.java
+++ b/src/main/java/dev/dfonline/flint/feature/impl/StateDebugDisplayFeature.java
@@ -31,13 +31,16 @@ public class StateDebugDisplayFeature implements RenderedFeature {
 
         ArrayList<Text> texts = new ArrayList<>();
         texts.add(literal("General State:").withColor(PaletteColor.PURPLE.value()));
+        texts.add(formatValue("Mode", ObjectUtil.toString(user.getMode(), Mode::getName)));
+        texts.add(formatValue("Location Confirmed", user.isLocationConfirmed() + ""));
+        texts.add(formatValue("In Plot", user.isInPlot() + ""));
+        texts.add(formatValue("Is Editor", user.isEditor() + ""));
         texts.add(formatValue("Node", ObjectUtil.toString(user.getNode(), Node::getName)));
         texts.add(formatValue("Node Id", user.getNodeId() + ""));
         texts.add(formatValue("Plot", ObjectUtil.toString(user.getPlot(), plot -> plot.getId() + "")));
         texts.add(formatValue("Plot Size", ObjectUtil.toString(user.getPlot(), plot -> plot.getSize().name())));
         texts.add(formatValue("Plot Size Is Known", ObjectUtil.toString(user.getPlot(), plot -> plot.isSizeKnown() + "")));
         texts.add(formatValue("Plot Has Underground", ObjectUtil.toString(user.getPlot(), plot -> plot.hasUnderground() + "")));
-        texts.add(formatValue("Mode", ObjectUtil.toString(user.getMode(), Mode::getName)));
         texts.add(formatValue("Dev Origin Location",
                 ObjectUtil.toString(user.getPlot(), plot -> ObjectUtil.toString(plot.getDevOrigin(), Object::toString))
         ));

--- a/src/main/java/dev/dfonline/flint/hypercube/Mode.java
+++ b/src/main/java/dev/dfonline/flint/hypercube/Mode.java
@@ -41,6 +41,30 @@ public enum Mode {
         return this.name;
     }
 
+    public boolean isAtSpawn() {
+        return this == SPAWN;
+    }
+
+    public boolean isInPlay() {
+        return this == PLAY;
+    }
+
+    public boolean isInDev() {
+        return this == DEV;
+    }
+
+    public boolean isInBuild() {
+        return this == BUILD;
+    }
+
+    public boolean isCodeSpectating() {
+        return this == CODE_SPECTATE;
+    }
+
+    public boolean isNone() {
+        return this == NONE;
+    }
+
     public boolean isInPlot() {
         return this.inPlot;
     }


### PR DESCRIPTION
Adds helper methods for checking the user's current mode, including variants that only return true when the location state has been confirmed by `/locate`.

- The mode tracker now marks inferred mode changes as unconfirmed and `/locate` results as confirmed.
- Added `Flint.getUser().isLocationConfirmed()`.
- Added simple `User` mode helpers like `isInPlay()`, `isInDev()`, `isInBuild()`, and `isInPlot()`.
- Added confirmed helper variants like `isConfirmedInPlay()` and `isConfirmedInPlot()`.
- Added matching simple mode checks to `Mode`.
- Updated the README and debug display for the new location confirmation state.