### PR TITLE
CommandSenderFeature plot commands and internal queue

### DIFF
--- a/src/main/java/dev/dfonline/flint/FlintAPI.java
+++ b/src/main/java/dev/dfonline/flint/FlintAPI.java
@@ -1,6 +1,7 @@
 package dev.dfonline.flint;
 
 import dev.dfonline.flint.feature.core.FeatureTrait;
+import dev.dfonline.flint.feature.impl.CommandSenderFeature;
 
 @SuppressWarnings("unused") // API, we don't use all methods
 public final class FlintAPI {
@@ -69,4 +70,21 @@ public final class FlintAPI {
         Flint.FEATURE_MANAGER.registerAll(features);
     }
 
+    /**
+     * Queues a command to be sent without triggering chat spam limits.
+     *
+     * @param command The command to send, with or without a leading slash.
+     */
+    public static void queueCommand(String command) {
+        CommandSenderFeature.queueCommand(command);
+    }
+
+    /**
+     * Queues a plot command to be sent without triggering chat spam limits.
+     *
+     * @param command The plot command to send, with or without a leading at sign.
+     */
+    public static void queuePlotCommand(String command) {
+        CommandSenderFeature.queuePlotCommand(command);
+    }
 }

--- a/src/main/java/dev/dfonline/flint/feature/impl/CommandSenderFeature.java
+++ b/src/main/java/dev/dfonline/flint/feature/impl/CommandSenderFeature.java
@@ -1,8 +1,10 @@
 package dev.dfonline.flint.feature.impl;
 
 import dev.dfonline.flint.Flint;
+import dev.dfonline.flint.FlintAPI;
 import dev.dfonline.flint.feature.trait.PacketListeningFeature;
 import dev.dfonline.flint.feature.trait.TickedFeature;
+import dev.dfonline.flint.hypercube.Mode;
 import dev.dfonline.flint.util.RateLimiter;
 import dev.dfonline.flint.util.result.EventResult;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
@@ -13,25 +15,39 @@ import net.minecraft.network.packet.c2s.play.CommandExecutionC2SPacket;
 import java.util.ArrayDeque;
 
 /**
- * Queues up commands and sends while avoiding getting kicked for spam.
+ * Queues up commands and plot commands and sends them while avoiding getting kicked for spam.
  */
 public final class CommandSenderFeature implements PacketListeningFeature, TickedFeature {
 
     // Vanilla Minecraft uses an increment of 20 and a threshold of 200.
     // We have a lower threshold for extra safety and to account for lag.
     private static final RateLimiter rateLimiter = new RateLimiter(20, 160);
-    private static final ArrayDeque<String> commandQueue = new ArrayDeque<>();
+    private static final ArrayDeque<QueuedMessage> priorityQueue = new ArrayDeque<>();
+    private static final ArrayDeque<QueuedMessage> queue = new ArrayDeque<>();
 
     public static void queue(String command) {
-        commandQueue.add(command);
+        queueCommand(command);
+    }
+
+    public static void queueCommand(String command) {
+        queue.add(QueuedMessage.command(normalizeCommand(command)));
+    }
+
+    public static void queuePlotCommand(String command) {
+        queue.add(QueuedMessage.plotCommand(normalizePlotCommand(command)));
+    }
+
+    static void queueInternalCommand(String command) {
+        priorityQueue.add(QueuedMessage.command(normalizeCommand(command)));
     }
 
     public static void clearQueue() {
-        commandQueue.clear();
+        priorityQueue.clear();
+        queue.clear();
     }
 
     public static int queueSize() {
-        return commandQueue.size();
+        return priorityQueue.size() + queue.size();
     }
 
     @Override
@@ -43,9 +59,9 @@ public final class CommandSenderFeature implements PacketListeningFeature, Ticke
     public void tick() {
         rateLimiter.tick();
         ClientPlayNetworkHandler networkHandler = Flint.getClient().getNetworkHandler();
-        if (networkHandler != null && !rateLimiter.isRateLimited() && !commandQueue.isEmpty()) {
+        if (networkHandler != null && !rateLimiter.isRateLimited() && queueSize() > 0) {
             // No need to increment here, since our packet listener will do that for us.
-            networkHandler.sendChatCommand(commandQueue.pop());
+            sendNextMessage(networkHandler);
         }
     }
 
@@ -58,4 +74,94 @@ public final class CommandSenderFeature implements PacketListeningFeature, Ticke
         return EventResult.PASS;
     }
 
+    private static void sendNextMessage(ClientPlayNetworkHandler networkHandler) {
+        ArrayDeque<QueuedMessage> messageQueue = priorityQueue.isEmpty() ? queue : priorityQueue;
+        QueuedMessage message = messageQueue.peek();
+
+        if (message == null) {
+            return;
+        }
+
+        SendResult result = message.send(networkHandler);
+        if (result != SendResult.WAIT) {
+            messageQueue.pop();
+        }
+    }
+
+    private static String normalizeCommand(String command) {
+        String normalizedCommand = command.trim();
+        if (normalizedCommand.startsWith("/")) {
+            normalizedCommand = normalizedCommand.substring(1);
+        }
+
+        return normalizedCommand;
+    }
+
+    private static String normalizePlotCommand(String command) {
+        String normalizedCommand = command.trim();
+        if (normalizedCommand.startsWith("@")) {
+            normalizedCommand = normalizedCommand.substring(1);
+        }
+
+        return normalizedCommand;
+    }
+
+    private enum QueuedMessageType {
+        COMMAND,
+        PLOT_COMMAND
+    }
+
+    private enum SendResult {
+        SENT,
+        CANCELLED,
+        WAIT
+    }
+
+    private enum PlotCommandState {
+        SEND,
+        CANCEL,
+        WAIT
+    }
+
+    private record QueuedMessage(QueuedMessageType type, String content) {
+
+        private static QueuedMessage command(String command) {
+            return new QueuedMessage(QueuedMessageType.COMMAND, command);
+        }
+
+        private static QueuedMessage plotCommand(String command) {
+            return new QueuedMessage(QueuedMessageType.PLOT_COMMAND, command);
+        }
+
+        private SendResult send(ClientPlayNetworkHandler networkHandler) {
+            if (this.type == QueuedMessageType.PLOT_COMMAND) {
+                PlotCommandState state = getPlotCommandState();
+                if (state == PlotCommandState.WAIT) {
+                    return SendResult.WAIT;
+                }
+                if (state == PlotCommandState.CANCEL) {
+                    return SendResult.CANCELLED;
+                }
+            }
+
+            switch (this.type) {
+                case COMMAND -> networkHandler.sendChatCommand(this.content);
+                case PLOT_COMMAND -> networkHandler.sendChatMessage("@" + this.content);
+            }
+            return SendResult.SENT;
+        }
+    }
+
+    private static PlotCommandState getPlotCommandState() {
+        if (!FlintAPI.shouldConfirmLocationWithLocate()) {
+            return PlotCommandState.SEND;
+        }
+
+        Mode mode = Flint.getUser().getMode();
+        if (mode == Mode.PLAY) {
+            return PlotCommandState.SEND;
+        }
+
+        return PlotCommandState.CANCEL;
+    }
 }

--- a/src/main/java/dev/dfonline/flint/feature/impl/LocateFeature.java
+++ b/src/main/java/dev/dfonline/flint/feature/impl/LocateFeature.java
@@ -69,7 +69,7 @@ public class LocateFeature implements PacketListeningFeature {
             awaitingResponse = true;
             Pair<String, CompletableFuture<LocateResult>> currentRequest = locateRequests.peek();
 
-            CommandSenderFeature.queue("locate " + currentRequest.first());
+            CommandSenderFeature.queueInternalCommand("locate " + currentRequest.first());
         }
     }
 

--- a/src/main/resources/assets/flint/lang/en_us.json
+++ b/src/main/resources/assets/flint/lang/en_us.json
@@ -1,8 +1,8 @@
 {
   "flint.command.flint": "You're using Flint!",
   "flint.command.flint.mode": "Currently in mode %s on plot %s at node %s",
-  "flint.command.flint.clear_queue.success": "Cleared the command queue, any pending commands have been cancelled",
-  "flint.command.flint.clear_queue.empty": "No commands in the queue to clear",
+  "flint.command.flint.clear_queue.success": "Cleared the outgoing message queue, any pending messages have been cancelled",
+  "flint.command.flint.clear_queue.empty": "No messages in the queue to clear",
   "flint.command.flint.locate_test.success": "Located player %s, mode %s, plot %s, node %s",
   "flint.command.flint.locate_test.fail": "Failed to locate: %s",
   "flint.command.flint.action_dump.fail.start": "Failed to start reading the action dump, make sure you are on Node Beta, if you are, something might have gone wrong",


### PR DESCRIPTION
Adds an internal priority queue and support for queuing both regular commands and plot commands.

- Added a Flint-internal priority queue for important internal commands like `/locate` in `LocateFeature`.
- Added ability to send plot commands through `CommandSenderFeature`.
- Added public `FlintAPI.queueCommand(...)` and `FlintAPI.queuePlotCommand(...)` helpers.