### PR TITLE
Server patch detection and actiondump metadata

### DIFF
--- a/src/main/java/dev/dfonline/flint/Flint.java
+++ b/src/main/java/dev/dfonline/flint/Flint.java
@@ -10,6 +10,7 @@ import dev.dfonline.flint.feature.impl.GetActionDumpFeature;
 import dev.dfonline.flint.feature.impl.LocateFeature;
 import dev.dfonline.flint.feature.impl.ModeTrackerFeature;
 import dev.dfonline.flint.feature.impl.PacketLoggerFeature;
+import dev.dfonline.flint.feature.impl.ServerPatchFeature;
 import dev.dfonline.flint.feature.impl.StateDebugDisplayFeature;
 import dev.dfonline.flint.feature.trait.CommandFeature;
 import dev.dfonline.flint.feature.trait.ConnectionListeningFeature;
@@ -74,6 +75,7 @@ public class Flint implements ClientModInitializer {
 
                 // Functionality
                 new ModeTrackerFeature(),
+                new ServerPatchFeature(),
                 new GetActionDumpFeature(),
                 new FlintCommandFeature()
         );

--- a/src/main/java/dev/dfonline/flint/FlintAPI.java
+++ b/src/main/java/dev/dfonline/flint/FlintAPI.java
@@ -1,6 +1,10 @@
 package dev.dfonline.flint;
 
 import dev.dfonline.flint.feature.core.FeatureTrait;
+import dev.dfonline.flint.hypercube.ServerPatch;
+import dev.dfonline.flint.hypercube.ServerPatchSet;
+import dev.dfonline.flint.hypercube.ServerPatches;
+import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("unused") // API, we don't use all methods
 public final class FlintAPI {
@@ -49,6 +53,20 @@ public final class FlintAPI {
      */
     public static boolean isDebugging() {
         return debugging;
+    }
+
+    /**
+     * @return The known server patches, split by server target.
+     */
+    public static ServerPatchSet getServerPatches() {
+        return ServerPatches.current();
+    }
+
+    /**
+     * @return The known patch for the node the client is currently on, or {@code null} if it is not known yet.
+     */
+    public static @Nullable ServerPatch getServerPatch() {
+        return getServerPatches().patchForNode(Flint.getUser().getNode());
     }
 
     /**

--- a/src/main/java/dev/dfonline/flint/actiondump/ActionDump.java
+++ b/src/main/java/dev/dfonline/flint/actiondump/ActionDump.java
@@ -10,12 +10,14 @@ import dev.dfonline.flint.actiondump.particle.ParticleType;
 import dev.dfonline.flint.actiondump.potion.PotionType;
 import dev.dfonline.flint.actiondump.shop.CosmeticType;
 import dev.dfonline.flint.actiondump.sound.SoundType;
+import dev.dfonline.flint.hypercube.ServerPatchSet;
 import net.kyori.adventure.text.Component;
 
 import java.io.IOException;
 import java.nio.file.Files;
 
 public record ActionDump(
+        ServerPatchSet serverPatches,
         CodeBlockType[] codeblocks,
         ActionType[] actions,
         ValueCategory[] gameValueCategories,
@@ -27,6 +29,13 @@ public record ActionDump(
         PotionType[] potions,
         CosmeticType[] cosmetics
 ) {
+
+    public ActionDump {
+        if (serverPatches == null) {
+            serverPatches = ServerPatchSet.UNKNOWN;
+        }
+    }
+
     private static class Instance {
         private static ActionDump ACTION_DUMP;
     }

--- a/src/main/java/dev/dfonline/flint/feature/impl/GetActionDumpFeature.java
+++ b/src/main/java/dev/dfonline/flint/feature/impl/GetActionDumpFeature.java
@@ -1,11 +1,20 @@
 package dev.dfonline.flint.feature.impl;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
 import com.google.common.collect.Maps;
 import dev.dfonline.flint.Flint;
+import dev.dfonline.flint.FlintAPI;
 import dev.dfonline.flint.actiondump.ActionDumpFormat;
 import dev.dfonline.flint.feature.trait.ChatListeningFeature;
 import dev.dfonline.flint.feature.trait.PacketListeningFeature;
 import dev.dfonline.flint.hypercube.Node;
+import dev.dfonline.flint.hypercube.ServerPatchSet;
+import dev.dfonline.flint.hypercube.ServerPatches;
 import dev.dfonline.flint.util.ComponentUtil;
 import dev.dfonline.flint.util.file.FileUtil;
 import dev.dfonline.flint.util.message.impl.prefix.ErrorMessage;
@@ -14,36 +23,78 @@ import dev.dfonline.flint.util.result.ReplacementEventResult;
 import net.kyori.adventure.text.Component;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.text.Text;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 public class GetActionDumpFeature implements ChatListeningFeature, PacketListeningFeature {
 
     private static final int MS_IN_SEC = 1000;
+    private static final Gson ACTION_DUMP_GSON = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
+    private static boolean isPreparingActionDump = false;
     private static boolean isGettingActionDump = false;
     private static int lines;
     private static int length;
     private static long startTime;
+    private static @Nullable Node actionDumpNode;
     private static Map<ActionDumpFormat, StringBuilder> actionDumpProgression;
 
     public static void getActionDump(boolean allowNonObtainableActionDumpNodes) {
+        if (isPreparingActionDump || isGettingActionDump) {
+            return;
+        }
+
+        isPreparingActionDump = true;
+        resolveActionDumpNode(allowNonObtainableActionDumpNodes)
+                .thenAccept(node -> Flint.getClient().execute(() -> {
+                    isPreparingActionDump = false;
+                    startActionDump(allowNonObtainableActionDumpNodes, node);
+                }))
+                .exceptionally(throwable -> {
+                    Flint.getClient().execute(() -> {
+                        isPreparingActionDump = false;
+                        Flint.getUser().sendMessage(new ErrorMessage("flint.command.flint.action_dump.fail.node"));
+                    });
+                    return null;
+                });
+    }
+
+    private static CompletableFuture<Node> resolveActionDumpNode(boolean allowNonObtainableActionDumpNodes) {
+        Node node = Flint.getUser().getNode();
+
+        if (FlintAPI.shouldConfirmLocationWithLocate() && node != null) {
+            return CompletableFuture.completedFuture(node);
+        }
+
+        if (Flint.getClient().player == null) {
+            return CompletableFuture.completedFuture(node);
+        }
+
+        String playerName = Flint.getClient().player.getGameProfile().name();
+        return LocateFeature.requestLocate(playerName).thenApply(LocateFeature.LocateResult::node);
+    }
+
+    private static void startActionDump(boolean allowNonObtainableActionDumpNodes, Node node) {
         if (isGettingActionDump) {
             return;
         }
 
-        Node node = Flint.getUser().getNode();
-
-        if (!allowNonObtainableActionDumpNodes && (node == null || !node.isActionDumpObtainable())) {
+        if (node == null || (!allowNonObtainableActionDumpNodes && !node.isActionDumpObtainable())) {
             Flint.getUser().sendMessage(new ErrorMessage("flint.command.flint.action_dump.fail.node"));
             return;
         }
 
         isGettingActionDump = true;
+        actionDumpNode = node;
         ClientPlayNetworkHandler networkHandler = Flint.getClient().getNetworkHandler();
 
         if (networkHandler == null) {
             isGettingActionDump = false;
+            actionDumpNode = null;
             return;
         }
 
@@ -66,6 +117,7 @@ public class GetActionDumpFeature implements ChatListeningFeature, PacketListeni
 
         if (text.getString().startsWith("Error: ")) {
             isGettingActionDump = false;
+            actionDumpNode = null;
             Flint.getUser().sendMessage(new ErrorMessage("flint.command.flint.action_dump.fail.start"));
             return ReplacementEventResult.cancel();
         }
@@ -84,19 +136,81 @@ public class GetActionDumpFeature implements ChatListeningFeature, PacketListeni
             try {
                 for(var format : ActionDumpFormat.values()) {
                     var capturedData = actionDumpProgression.get(format);
-                    FileUtil.writeFile(format.getFile().getPath(), capturedData.toString());
+                    FileUtil.writeFile(format.getFile().getPath(), addServerPatches(capturedData.toString(), actionDumpNode));
                 }
                 Flint.getUser().sendMessage(new SuccessMessage("flint.command.flint.action_dump.success", Component.text((float) (System.currentTimeMillis() - startTime) / MS_IN_SEC), Component.text(lines), Component.text(length)));
-            } catch (IOException e) {
+            } catch (IOException | JsonParseException | IllegalStateException e) {
                 Flint.getUser().sendMessage(new ErrorMessage("flint.command.flint.action_dump.fail.write"));
                 return ReplacementEventResult.cancel();
             } finally {
                 // Let the garbage collector do its job.
                 actionDumpProgression = null;
+                actionDumpNode = null;
             }
         }
 
         return ReplacementEventResult.cancel();
+    }
+
+    private static String addServerPatches(String capturedData, @Nullable Node node) {
+        JsonObject actionDump = JsonParser.parseString(capturedData).getAsJsonObject();
+        actionDump.add("serverPatches", ServerPatches.current().withUnknownAssignedTo(node).toJson());
+        return ACTION_DUMP_GSON.toJson(actionDump);
+    }
+
+    public static boolean refreshExistingActionDumpPatchMetadata() {
+        boolean success = true;
+
+        for (var format : ActionDumpFormat.values()) {
+            Path path = format.getFile().getPath();
+
+            if (!Files.exists(path)) {
+                continue;
+            }
+
+            try {
+                refreshExistingActionDumpPatchMetadata(path);
+            } catch (IOException | JsonParseException | IllegalStateException e) {
+                success = false;
+            }
+        }
+
+        return success;
+    }
+
+    private static void refreshExistingActionDumpPatchMetadata(Path path) throws IOException {
+        JsonObject actionDump = JsonParser.parseString(Files.readString(path)).getAsJsonObject();
+        JsonElement serverPatchesElement = actionDump.get("serverPatches");
+
+        if (serverPatchesElement == null) {
+            return;
+        }
+
+        JsonObject serverPatches = serverPatchesElement.getAsJsonObject();
+        ServerPatchSet current = ServerPatches.current();
+        boolean changed = fillMissingServerPatch(serverPatches, "main", current.main());
+        changed |= fillMissingServerPatch(serverPatches, "beta", current.beta());
+        changed |= serverPatches.remove("unknown") != null;
+
+        if (!changed) {
+            return;
+        }
+
+        FileUtil.writeFile(path, ACTION_DUMP_GSON.toJson(actionDump));
+    }
+
+    private static boolean fillMissingServerPatch(JsonObject serverPatches, String key, String patch) {
+        if (patch == null) {
+            return false;
+        }
+
+        JsonElement existingPatch = serverPatches.get(key);
+        if (existingPatch != null && !existingPatch.isJsonNull()) {
+            return false;
+        }
+
+        serverPatches.addProperty(key, patch);
+        return true;
     }
 
 }

--- a/src/main/java/dev/dfonline/flint/feature/impl/ServerPatchFeature.java
+++ b/src/main/java/dev/dfonline/flint/feature/impl/ServerPatchFeature.java
@@ -1,0 +1,114 @@
+package dev.dfonline.flint.feature.impl;
+
+import dev.dfonline.flint.Flint;
+import dev.dfonline.flint.feature.trait.ChatListeningFeature;
+import dev.dfonline.flint.feature.trait.ConnectionListeningFeature;
+import dev.dfonline.flint.feature.trait.TickedFeature;
+import dev.dfonline.flint.hypercube.Node;
+import dev.dfonline.flint.hypercube.ServerPatch;
+import dev.dfonline.flint.hypercube.ServerPatchTarget;
+import dev.dfonline.flint.hypercube.ServerPatches;
+import dev.dfonline.flint.util.result.ReplacementEventResult;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ServerPatchFeature implements ChatListeningFeature, ConnectionListeningFeature, TickedFeature {
+
+    private static final Pattern CURRENT_PATCH_MESSAGE_PATTERN =
+            Pattern.compile("^Current patch: (?<patch>" + ServerPatch.REGEX + ")\\. See the patch notes with /patch!$");
+
+    private @Nullable String pendingPatch;
+    private @Nullable Node nodeWhenPatchWasSeen;
+
+    @Override
+    public boolean alwaysOn() {
+        return true;
+    }
+
+    @Override
+    public void onJoin() {
+        this.pendingPatch = null;
+        this.nodeWhenPatchWasSeen = null;
+    }
+
+    @Override
+    public void onDisconnect() {
+        this.pendingPatch = null;
+        this.nodeWhenPatchWasSeen = null;
+        ServerPatches.clear();
+    }
+
+    @Override
+    public void tick() {
+        if (this.pendingPatch != null) {
+            this.tryStorePatch();
+        }
+    }
+
+    @Override
+    public ReplacementEventResult<Text> onChatMessage(Text text, boolean actionbar) {
+        if (actionbar) {
+            return ReplacementEventResult.pass();
+        }
+
+        String message = Formatting.strip(text.getString());
+
+        if (message == null || message.isBlank()) {
+            return ReplacementEventResult.pass();
+        }
+
+        Flint.getClient().execute(() -> this.processChatMessage(message));
+
+        return ReplacementEventResult.pass();
+    }
+
+    private void processChatMessage(String message) {
+        String patch = extractCurrentPatch(message);
+
+        if (patch == null) {
+            return;
+        }
+
+        this.pendingPatch = patch;
+        this.nodeWhenPatchWasSeen = Flint.getUser().getNode();
+        ServerPatches.setUnknown(patch);
+        GetActionDumpFeature.refreshExistingActionDumpPatchMetadata();
+        this.tryStorePatch();
+    }
+
+    private static @Nullable String extractCurrentPatch(String message) {
+        Matcher matcher = CURRENT_PATCH_MESSAGE_PATTERN.matcher(message);
+        return matcher.find() ? matcher.group("patch") : null;
+    }
+
+    private void tryStorePatch() {
+        String patch = this.pendingPatch;
+        if (patch == null) {
+            return;
+        }
+
+        Node node = Flint.getUser().getNode();
+        if (node == null) {
+            return;
+        }
+
+        if (node == this.nodeWhenPatchWasSeen) {
+            return;
+        }
+
+        ServerPatchTarget target = ServerPatchTarget.fromNode(node);
+        if (target == null) {
+            return;
+        }
+
+        ServerPatches.set(target, patch);
+        GetActionDumpFeature.refreshExistingActionDumpPatchMetadata();
+        this.pendingPatch = null;
+        this.nodeWhenPatchWasSeen = null;
+    }
+
+}

--- a/src/main/java/dev/dfonline/flint/feature/impl/StateDebugDisplayFeature.java
+++ b/src/main/java/dev/dfonline/flint/feature/impl/StateDebugDisplayFeature.java
@@ -8,6 +8,7 @@ import dev.dfonline.flint.feature.trait.RenderedFeature;
 import dev.dfonline.flint.hypercube.Mode;
 import dev.dfonline.flint.hypercube.Node;
 import dev.dfonline.flint.hypercube.Plot;
+import dev.dfonline.flint.hypercube.ServerPatches;
 import dev.dfonline.flint.util.Logger;
 import dev.dfonline.flint.util.ObjectUtil;
 import dev.dfonline.flint.util.PaletteColor;
@@ -33,6 +34,7 @@ public class StateDebugDisplayFeature implements RenderedFeature {
         texts.add(literal("General State:").withColor(PaletteColor.PURPLE.value()));
         texts.add(formatValue("Node", ObjectUtil.toString(user.getNode(), Node::getName)));
         texts.add(formatValue("Node Id", user.getNodeId() + ""));
+        texts.add(formatValue("Patch", ObjectUtil.toString(ServerPatches.current().getForNode(user.getNode()), Object::toString)));
         texts.add(formatValue("Plot", ObjectUtil.toString(user.getPlot(), plot -> plot.getId() + "")));
         texts.add(formatValue("Plot Size", ObjectUtil.toString(user.getPlot(), plot -> plot.getSize().name())));
         texts.add(formatValue("Plot Size Is Known", ObjectUtil.toString(user.getPlot(), plot -> plot.isSizeKnown() + "")));
@@ -72,4 +74,3 @@ public class StateDebugDisplayFeature implements RenderedFeature {
     }
 
 }
-

--- a/src/main/java/dev/dfonline/flint/hypercube/ServerPatch.java
+++ b/src/main/java/dev/dfonline/flint/hypercube/ServerPatch.java
@@ -1,0 +1,80 @@
+package dev.dfonline.flint.hypercube;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.regex.Pattern;
+
+public record ServerPatch(String value) implements Comparable<ServerPatch> {
+
+    public static final String REGEX = "\\d+\\.\\d+(?:\\.\\d+)?";
+
+    private static final Pattern PATCH_PATTERN = Pattern.compile("^" + REGEX + "$");
+
+    public ServerPatch {
+        value = value.trim();
+
+        if (!PATCH_PATTERN.matcher(value).matches()) {
+            throw new IllegalArgumentException("Invalid server patch: " + value);
+        }
+    }
+
+    public static ServerPatch parse(String value) {
+        return new ServerPatch(value);
+    }
+
+    public static @Nullable ServerPatch tryParse(@Nullable String value) {
+        if (value == null) {
+            return null;
+        }
+
+        try {
+            return parse(value);
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+
+    public boolean isAtLeast(String minimumPatch) {
+        return this.compareTo(parse(minimumPatch)) >= 0;
+    }
+
+    @Override
+    public int compareTo(@NotNull ServerPatch other) {
+        return compareNumbers(this.value.split("\\."), other.value.split("\\."));
+    }
+
+    private static int compareNumbers(String[] left, String[] right) {
+        int maxLength = Math.max(left.length, right.length);
+
+        for (int index = 0; index < maxLength; index++) {
+            String leftPart = index < left.length ? left[index] : "0";
+            String rightPart = index < right.length ? right[index] : "0";
+            int comparison = compareNumberPart(leftPart, rightPart);
+
+            if (comparison != 0) {
+                return comparison;
+            }
+        }
+
+        return 0;
+    }
+
+    private static int compareNumberPart(String left, String right) {
+        String normalizedLeft = trimLeadingZeroes(left);
+        String normalizedRight = trimLeadingZeroes(right);
+        int lengthComparison = Integer.compare(normalizedLeft.length(), normalizedRight.length());
+
+        if (lengthComparison != 0) {
+            return lengthComparison;
+        }
+
+        return normalizedLeft.compareTo(normalizedRight);
+    }
+
+    private static String trimLeadingZeroes(String number) {
+        String normalized = number.replaceFirst("^0+", "");
+        return normalized.isEmpty() ? "0" : normalized;
+    }
+
+}

--- a/src/main/java/dev/dfonline/flint/hypercube/ServerPatchSet.java
+++ b/src/main/java/dev/dfonline/flint/hypercube/ServerPatchSet.java
@@ -1,0 +1,96 @@
+package dev.dfonline.flint.hypercube;
+
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import org.jetbrains.annotations.Nullable;
+
+public record ServerPatchSet(
+        @Nullable String main,
+        @Nullable String beta,
+        @Nullable String unknown
+) {
+
+    public static final ServerPatchSet UNKNOWN = new ServerPatchSet(null, null, null);
+
+    public ServerPatchSet {
+        main = normalizeStoredPatch(main);
+        beta = normalizeStoredPatch(beta);
+        unknown = normalizeStoredPatch(unknown);
+    }
+
+    public @Nullable String get(ServerPatchTarget target) {
+        return switch (target) {
+            case MAIN -> this.main;
+            case BETA -> this.beta;
+        };
+    }
+
+    public @Nullable ServerPatch patch(ServerPatchTarget target) {
+        return ServerPatch.tryParse(this.get(target));
+    }
+
+    public @Nullable String getForNode(@Nullable Node node) {
+        ServerPatchTarget target = ServerPatchTarget.fromNode(node);
+        if (target == null) {
+            return this.unknown;
+        }
+
+        String patch = this.get(target);
+        return patch == null ? this.unknown : patch;
+    }
+
+    public @Nullable ServerPatch patchForNode(@Nullable Node node) {
+        return ServerPatch.tryParse(this.getForNode(node));
+    }
+
+    public ServerPatchSet with(ServerPatchTarget target, String patch) {
+        String normalizedPatch = ServerPatch.parse(patch).value();
+        String nextUnknown = normalizedPatch.equals(this.unknown) ? null : this.unknown;
+
+        return switch (target) {
+            case MAIN -> new ServerPatchSet(normalizedPatch, this.beta, nextUnknown);
+            case BETA -> new ServerPatchSet(this.main, normalizedPatch, nextUnknown);
+        };
+    }
+
+    public ServerPatchSet withUnknown(String patch) {
+        String normalizedPatch = ServerPatch.parse(patch).value();
+
+        if (normalizedPatch.equals(this.main) || normalizedPatch.equals(this.beta)) {
+            return this;
+        }
+
+        return new ServerPatchSet(this.main, this.beta, normalizedPatch);
+    }
+
+    public ServerPatchSet withUnknownAssignedTo(@Nullable Node node) {
+        ServerPatchTarget target = ServerPatchTarget.fromNode(node);
+        if (target == null || this.unknown == null) {
+            return this;
+        }
+
+        return this.with(target, this.unknown);
+    }
+
+    public JsonObject toJson() {
+        JsonObject json = new JsonObject();
+        addNullableString(json, "main", this.main);
+        addNullableString(json, "beta", this.beta);
+        return json;
+    }
+
+    private static void addNullableString(JsonObject json, String key, @Nullable String value) {
+        json.add(key, value == null ? JsonNull.INSTANCE : new JsonPrimitive(value));
+    }
+
+    private static @Nullable String normalizeStoredPatch(@Nullable String patch) {
+        if (patch == null) {
+            return null;
+        }
+
+        String normalizedPatch = patch.trim();
+        return normalizedPatch.isEmpty() ? null : normalizedPatch;
+    }
+
+}

--- a/src/main/java/dev/dfonline/flint/hypercube/ServerPatchTarget.java
+++ b/src/main/java/dev/dfonline/flint/hypercube/ServerPatchTarget.java
@@ -1,0 +1,16 @@
+package dev.dfonline.flint.hypercube;
+
+import org.jetbrains.annotations.Nullable;
+
+public enum ServerPatchTarget {
+    MAIN,
+    BETA;
+
+    public static @Nullable ServerPatchTarget fromNode(@Nullable Node node) {
+        if (node == null) {
+            return null;
+        }
+
+        return node == Node.BETA ? BETA : MAIN;
+    }
+}

--- a/src/main/java/dev/dfonline/flint/hypercube/ServerPatches.java
+++ b/src/main/java/dev/dfonline/flint/hypercube/ServerPatches.java
@@ -1,0 +1,26 @@
+package dev.dfonline.flint.hypercube;
+
+public final class ServerPatches {
+
+    private static ServerPatchSet current = ServerPatchSet.UNKNOWN;
+
+    private ServerPatches() {
+    }
+
+    public static ServerPatchSet current() {
+        return current;
+    }
+
+    public static void set(ServerPatchTarget target, String patch) {
+        current = current.with(target, patch);
+    }
+
+    public static void setUnknown(String patch) {
+        current = current.withUnknown(patch);
+    }
+
+    public static void clear() {
+        current = ServerPatchSet.UNKNOWN;
+    }
+
+}


### PR DESCRIPTION
Adds server patch tracking and includes patch metadata in generated actiondumps for easier validation.

- Added server patch detection from DiamondFire's current patch chat message.
- Added `ServerPatch`, `ServerPatchSet`, `ServerPatchTarget`, and live patch state tracking.
- Added `FlintAPI.getServerPatch()` and `FlintAPI.getServerPatches()` helpers.
- Added `serverPatches` metadata to actiondump JSON output.
- Uses actiondump location resolution to assign unknown live patches to the correct main/beta metadata field when writing actiondumps.
- Refreshes existing actiondump metadata when newly known main/beta patch data becomes available.
  - This does not affect actiondumps generated before this metadata existed.
- Added current patch state to the debug display.