### PR TITLE
Versioning improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,8 @@ jobs:
         with:
           java-version: 21
           distribution: "temurin"
-      - name: Inject Version File
-        run: echo "${{ github.run_number }}" > src/main/resources/flint_version.txt
       - name: Build with Gradle
-        run: ./gradlew build '-Pversion=${{ github.run_number }}'
+        run: ./gradlew build '-Pmod_version=${{ github.run_number }}'
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -53,5 +51,5 @@ jobs:
             fabric
           game-versions: |-
             1.21.11
-          files: '["./build/libs/Flint-1.0.0.jar", "./build/libs/Flint-1.0.0-sources.jar"]'
-          primary-file: "Flint-1.0.0.jar"
+          files: '["./build/libs/Flint-${{ github.run_number }}.jar", "./build/libs/Flint-${{ github.run_number }}-sources.jar"]'
+          primary-file: "Flint-${{ github.run_number }}.jar"

--- a/README.md
+++ b/README.md
@@ -150,11 +150,9 @@ Use the Modrinth Maven repository to depend on Flint in your project.
 Flint updates on a **rolling release** schedule, once a push is made to the main branch, a new version is released.
 The latest release will be the most recent GitHub release, or other most recent release on Modrinth.
 
-Starting with the release containing this change, each published build uses its rolling release number as its Fabric
-mod version.  
+Starting with the release containing this change, each published build uses its rolling release number as its Fabric mod version.  
 For example, GitHub/Modrinth release `v123` has the Fabric version `123`.  
-This lets your mod require the
-oldest compatible Flint build in `fabric.mod.json`:
+This lets your mod require the oldest compatible Flint build in `fabric.mod.json`:
 
 ```json
 {
@@ -165,8 +163,7 @@ oldest compatible Flint build in `fabric.mod.json`:
 ```
 
 Fabric will then prevent the mod from loading with an older Flint build.  
-The `v` prefix is part of the release and
-Modrinth Maven version name, but is not part of the Fabric version.
+The `v` prefix is part of the release and Modrinth Maven version name, but is not part of the Fabric version.
 
 ### Build Script Example
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,24 @@ Use the Modrinth Maven repository to depend on Flint in your project.
 Flint updates on a **rolling release** schedule, once a push is made to the main branch, a new version is released.
 The latest release will be the most recent GitHub release, or other most recent release on Modrinth.
 
+Starting with the release containing this change, each published build uses its rolling release number as its Fabric
+mod version.  
+For example, GitHub/Modrinth release `v123` has the Fabric version `123`.  
+This lets your mod require the
+oldest compatible Flint build in `fabric.mod.json`:
+
+```json
+{
+  "depends": {
+    "flint": ">=123"
+  }
+}
+```
+
+Fabric will then prevent the mod from loading with an older Flint build.  
+The `v` prefix is part of the release and
+Modrinth Maven version name, but is not part of the Fabric version.
+
 ### Build Script Example
 
 > [!WARNING]

--- a/src/main/java/dev/dfonline/flint/Flint.java
+++ b/src/main/java/dev/dfonline/flint/Flint.java
@@ -29,6 +29,7 @@ import net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
 import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderEvents;
+import net.fabricmc.loader.api.FabricLoader;
 import net.kyori.adventure.platform.modcommon.MinecraftAudiences;
 import net.kyori.adventure.platform.modcommon.MinecraftClientAudiences;
 import net.minecraft.client.MinecraftClient;
@@ -39,6 +40,11 @@ public class Flint implements ClientModInitializer {
 
     public static final String MOD_ID = "flint";
     public static final String MOD_NAME = "Flint";
+    public static final String MOD_VERSION = FabricLoader.getInstance()
+            .getModContainer(MOD_ID)
+            .map(container -> container.getMetadata().getVersion().getFriendlyString())
+            .orElse("unknown");
+
     public static final FeatureManager FEATURE_MANAGER = new FeatureManager();
     public static final MinecraftAudiences AUDIENCE = MinecraftClientAudiences.builder().build();
 

--- a/src/main/java/dev/dfonline/flint/util/FlintUpdate.java
+++ b/src/main/java/dev/dfonline/flint/util/FlintUpdate.java
@@ -1,5 +1,6 @@
 package dev.dfonline.flint.util;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import dev.dfonline.flint.Flint;
@@ -15,14 +16,17 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 
 public final class FlintUpdate {
 
     private static final Logger LOGGER = Logger.of(FlintUpdate.class);
-    private static final String MOD_REPOSITORY = "DFOnline/Flint";
+    private static final String MODRINTH_PROJECT = "dBv9so2c";
+    private static final String MOD_LOADER = "fabric";
     private static final String MODRINTH_URL = "https://modrinth.com/mod/flint/versions";
     private static final String MOD_VERSION = getCurrentVersion();
     private static final String UNKNOWN_VERSION = "unknown";
@@ -32,28 +36,62 @@ public final class FlintUpdate {
     }
 
     public static void fetchLatestRelease() {
-        String url = String.format("https://api.github.com/repos/%s/releases/latest", MOD_REPOSITORY);
+        String minecraftVersion = FabricLoader.getInstance()
+                .getModContainer("minecraft")
+                .map(container -> container.getMetadata().getVersion().getFriendlyString())
+                .orElse(UNKNOWN_VERSION);
+
+        if (minecraftVersion.equals(UNKNOWN_VERSION)) {
+            LOGGER.error("Failed to get the current Minecraft version");
+            return;
+        }
+
+        String url = String.format(
+                "https://api.modrinth.com/v2/project/%s/version?game_versions=%s&loaders=%s&include_changelog=false",
+                MODRINTH_PROJECT,
+                encodeFilter(minecraftVersion),
+                encodeFilter(MOD_LOADER)
+        );
 
         try (HttpClient client = HttpClient.newHttpClient()) {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
+                    .header("User-Agent", "DFOnline/Flint/" + MOD_VERSION)
                     .build();
 
             client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
-                    .thenApply(HttpResponse::body)
-                    .thenAccept(responseBody -> {
-                        JsonObject jsonResponse = JsonParser.parseString(responseBody).getAsJsonObject();
-                        if (!jsonResponse.has("tag_name")) {
-                            throw new RuntimeException("Expected a response with tag_name, instead got: " + responseBody);
+                    .thenApply(response -> {
+                        if (response.statusCode() != 200) {
+                            throw new RuntimeException("Expected a successful response, instead got: " + response.statusCode());
                         }
-                        latestVersion = jsonResponse.get("tag_name").getAsString().substring(1);
-                        LOGGER.info("Latest version: v{}", latestVersion);
+                        return response.body();
+                    })
+                    .thenAccept(responseBody -> {
+                        JsonArray versions = JsonParser.parseString(responseBody).getAsJsonArray();
+                        if (versions.isEmpty()) {
+                            LOGGER.info("No Flint releases found for Minecraft {}", minecraftVersion);
+                            return;
+                        }
+
+                        JsonObject latestRelease = versions.get(0).getAsJsonObject();
+                        if (!latestRelease.has("version_number")) {
+                            throw new RuntimeException("Expected a response with version_number, instead got: " + responseBody);
+                        }
+
+                        latestVersion = latestRelease.get("version_number").getAsString().replaceFirst("^v", "");
+                        LOGGER.info("Latest version for Minecraft {}: v{}", minecraftVersion, latestVersion);
                     })
                     .exceptionally(e -> {
                         LOGGER.error("Error while fetching version", e);
                         return null;
                     });
         }
+    }
+
+    private static String encodeFilter(String value) {
+        JsonArray filter = new JsonArray();
+        filter.add(value);
+        return URLEncoder.encode(filter.toString(), StandardCharsets.UTF_8);
     }
 
     private static String getCurrentVersion() {
@@ -80,18 +118,11 @@ public final class FlintUpdate {
         }
 
         try {
-            int latest = Integer.parseInt(latestVersion);
-            int current = Integer.parseInt(MOD_VERSION);
-
-            // Ignore if outdated for less than 5 versions.
-            if (latest - current < 5) {
-                return;
-            }
             // We are outdated, inform the user.
             if (Flint.getClient().player != null) {
                 Flint.getUser().sendMessage(new InfoMessage("flint.update",
                         Component.text("v" + MOD_VERSION),
-                        Component.text("v" + latest),
+                        Component.text("v" + latestVersion),
                         Component.translatable("flint.update.link", PaletteColor.SKY_LIGHT_2)
                                 .clickEvent(ClickEvent.openUrl(MODRINTH_URL))
                                 .hoverEvent(HoverEvent.showText(Component.text(MODRINTH_URL, PaletteColor.GRAY_LIGHT)))

--- a/src/main/java/dev/dfonline/flint/util/FlintUpdate.java
+++ b/src/main/java/dev/dfonline/flint/util/FlintUpdate.java
@@ -17,6 +17,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 public final class FlintUpdate {
 
@@ -24,7 +25,6 @@ public final class FlintUpdate {
     private static final String MODRINTH_PROJECT = "dBv9so2c";
     private static final String MOD_LOADER = "fabric";
     private static final String MODRINTH_URL = "https://modrinth.com/mod/flint/versions";
-    private static final String MOD_VERSION = getCurrentVersion();
     private static final String UNKNOWN_VERSION = "unknown";
     private static @Nullable String latestVersion = null;
 
@@ -52,7 +52,7 @@ public final class FlintUpdate {
         try (HttpClient client = HttpClient.newHttpClient()) {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
-                    .header("User-Agent", "DFOnline/Flint/" + MOD_VERSION)
+                    .header("User-Agent", "DFOnline/Flint/v" + Flint.MOD_VERSION)
                     .build();
 
             client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
@@ -90,16 +90,8 @@ public final class FlintUpdate {
         return URLEncoder.encode(filter.toString(), StandardCharsets.UTF_8);
     }
 
-    private static String getCurrentVersion() {
-        return FabricLoader.getInstance()
-                .getModContainer(Flint.MOD_ID)
-                .map(container -> container.getMetadata().getVersion().getFriendlyString())
-                .orElse(UNKNOWN_VERSION);
-    }
-
-
     public static void sendUpdateMessage() {
-        if (latestVersion == null || MOD_VERSION.equals(latestVersion) || MOD_VERSION.equals(UNKNOWN_VERSION)) {
+        if (latestVersion == null || Objects.equals(Flint.MOD_VERSION, latestVersion) || Objects.equals(Flint.MOD_VERSION, UNKNOWN_VERSION)) {
             return;
         }
 
@@ -107,7 +99,7 @@ public final class FlintUpdate {
             // We are outdated, inform the user.
             if (Flint.getClient().player != null) {
                 Flint.getUser().sendMessage(new InfoMessage("flint.update",
-                        Component.text("v" + MOD_VERSION),
+                        Component.text("v" + Flint.MOD_VERSION),
                         Component.text("v" + latestVersion),
                         Component.translatable("flint.update.link", PaletteColor.SKY_LIGHT_2)
                                 .clickEvent(ClickEvent.openUrl(MODRINTH_URL))

--- a/src/main/java/dev/dfonline/flint/util/FlintUpdate.java
+++ b/src/main/java/dev/dfonline/flint/util/FlintUpdate.java
@@ -11,10 +11,6 @@ import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
 import org.jspecify.annotations.Nullable;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
@@ -95,20 +91,10 @@ public final class FlintUpdate {
     }
 
     private static String getCurrentVersion() {
-        try (InputStream input = Flint.class.getClassLoader().getResourceAsStream("flint_version.txt")) {
-            if (input == null) {
-                return UNKNOWN_VERSION;
-            }
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(input))) {
-                return reader.readLine();
-            }
-        } catch (IOException e) {
-            if (FabricLoader.getInstance().isDevelopmentEnvironment()) {
-                return UNKNOWN_VERSION;
-            }
-            LOGGER.error("Failed to get mod version", e);
-            return UNKNOWN_VERSION;
-        }
+        return FabricLoader.getInstance()
+                .getModContainer(Flint.MOD_ID)
+                .map(container -> container.getMetadata().getVersion().getFriendlyString())
+                .orElse(UNKNOWN_VERSION);
     }
 
 


### PR DESCRIPTION
Switched update checker to use Modrinth instead of GitHub Releases.
Filters releases by the current Minecraft version and avoids suggesting incompatible Flint versions.

Changed Flint's actual mod version to use the release number instead of always being `1.0.0`.
This means other mods can now require a specific Flint version directly with something like `"flint": ">=58"`.